### PR TITLE
Link support

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
       box-sizing: border-box;
     }
 
+    .links a {
+      cursor: pointer;
+    }
+
     .app-container {
       height: 100%;
     }

--- a/renderer.js
+++ b/renderer.js
@@ -2,6 +2,7 @@
 // be executed in the renderer process for that window.
 // All of the Node.js APIs are available in this process.
 
+const electron = require('electron');
 const React = require("react");
 const ReactDOM = require("react-dom");
 const App = require("./dist/containers/App");
@@ -9,3 +10,28 @@ const App = require("./dist/containers/App");
 ReactDOM.render(React.createElement(App), document.getElementById("app"));
 
 console.log(`Renderer JavaScript Startup Time: ${performance.now() - global.startTime}ms`);
+
+// Allow opening links in browser with CMD+CLICK
+(() => {
+  document.addEventListener('click', e => {
+    if (e.target.tagName === 'A') {
+      const url = e.target.getAttribute('href');
+      if (url && e.metaKey) {
+        electron.shell.openExternal(url)
+        e.preventDefault();
+      }
+    }
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Meta') {
+      document.body.classList.add('links');
+    }
+  });
+
+  document.addEventListener('keyup', e => {
+    if (e.key === 'Meta') {
+      document.body.classList.remove('links');
+    }
+  });
+})();

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -18,11 +18,16 @@ const EditorWrapper = styled.div`
   box-sizing: border-box;
 
   & > div {
-    height: 100%;
+    flex: 1;
     padding: 8px 28px 0;
 
     & > div {
       height: 100%;
+
+      /* Hide portal */
+      & > div:first-child {
+        display: none;
+      }
     }
   }
 
@@ -69,6 +74,7 @@ export default function Editor({ defaultValue, onChange }) {
           render={actions => (
             <FabricEditor
               appearance="chromeless"
+              allowHyperlinks={true}
               allowLists={true}
               allowTasksAndDecisions={true}
               allowTextFormatting={true}


### PR DESCRIPTION
Admittedly this is "a bit" hacky..

* I'm hiding the portal where popups are rendered
* Adding event listeners to document so that we can open links with CMD+CLICK - I don't think default behaviour should be to open the links since you might want to put the cursor inside it to edit.

Thoughts?